### PR TITLE
RssItem now is a Date instead of a String

### DIFF
--- a/app/src/main/java/me/toptas/rssconvertersample/RssItemsAdapter.kt
+++ b/app/src/main/java/me/toptas/rssconvertersample/RssItemsAdapter.kt
@@ -41,7 +41,7 @@ internal class RssItemsAdapter(private val listener: OnItemClickListener) : Recy
         val item = itemList[position]
         holder.apply {
             textTitle.text = item.title
-            textPubDate.text = item.publishDate
+            textPubDate.text = item.publishDate?.toString()
 
             if (item.image != null) {
                 Picasso.get()

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -26,15 +26,24 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-
+    // https://mvnrepository.com/artifact/org.pojava/datetime
+    implementation group: 'org.pojava', name: 'datetime', version: '3.0.2'
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
+    androidTestImplementation 'com.squareup.retrofit2:retrofit-mock:2.2.0'
+
 }
 
 repositories {
     mavenCentral()
+}
+
+tasks.withType(Test) {
+    testLogging {
+        events "started", "passed", "skipped", "failed"
+    }
 }

--- a/library/src/main/java/me/toptas/rssconverter/RssItem.kt
+++ b/library/src/main/java/me/toptas/rssconverter/RssItem.kt
@@ -1,6 +1,7 @@
 package me.toptas.rssconverter
 
 import java.io.Serializable
+import java.util.Date
 
 /**
  * Model for Rss Item
@@ -16,7 +17,7 @@ class RssItem : Serializable {
             field = link?.trim { it <= ' ' }
         }
     var image: String? = null
-    var publishDate: String? = null
+    var publishDate: Date? = null
     var description: String? = null
 
 

--- a/library/src/main/java/me/toptas/rssconverter/XMLParser.kt
+++ b/library/src/main/java/me/toptas/rssconverter/XMLParser.kt
@@ -1,12 +1,13 @@
 package me.toptas.rssconverter
 
 import android.util.Log
+import org.pojava.datetime.DateTime
+import org.pojava.datetime.DateTimeConfig
 import org.xml.sax.Attributes
 import org.xml.sax.SAXException
 import org.xml.sax.helpers.DefaultHandler
-import java.text.ParseException
-import java.text.SimpleDateFormat
-import java.util.*
+import java.lang.Exception
+import java.util.Date
 
 /**
  * RSS Feed XML parser
@@ -94,10 +95,8 @@ internal class XMLParser : DefaultHandler() {
                 }
                 PUBLISH_DATE -> date = elementValue?.let {
                     try{
-                        SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss",
-                                Locale(Locale.getDefault().displayLanguage))
-                                .parse(it)
-                    }catch (e: ParseException){
+                        DateTime.parse(it, DateTimeConfig.getGlobalDefault()).toDate()
+                    }catch (e: Exception){
                         Log.i(XMLParser::class.java.simpleName, "Careful! ${e}")
                         null
                     }

--- a/library/src/main/java/me/toptas/rssconverter/XMLParser.kt
+++ b/library/src/main/java/me/toptas/rssconverter/XMLParser.kt
@@ -1,8 +1,12 @@
 package me.toptas.rssconverter
 
+import android.util.Log
 import org.xml.sax.Attributes
 import org.xml.sax.SAXException
 import org.xml.sax.helpers.DefaultHandler
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.*
 
 /**
  * RSS Feed XML parser
@@ -18,7 +22,7 @@ internal class XMLParser : DefaultHandler() {
     private var title = EMPTY_STRING
     private var link: String? = null
     private var image: String? = null
-    private var date: String? = null
+    private var date: Date? = null
     private var description: String? = null
 
     private var rssItem: RssItem? = null
@@ -73,7 +77,7 @@ internal class XMLParser : DefaultHandler() {
                     }
                     link = EMPTY_STRING
                     image = null
-                    date = EMPTY_STRING
+                    date = null
                 }
                 TITLE -> if (!qName.contains(MEDIA)) {
                     parsingTitle = false
@@ -88,7 +92,16 @@ internal class XMLParser : DefaultHandler() {
                 IMAGE, URL -> if (elementValue != null && elementValue?.isNotEmpty() == true) {
                     image = elementValue
                 }
-                PUBLISH_DATE -> date = elementValue
+                PUBLISH_DATE -> date = elementValue?.let {
+                    try{
+                        SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss",
+                                Locale(Locale.getDefault().displayLanguage))
+                                .parse(it)
+                    }catch (e: ParseException){
+                        Log.i(XMLParser::class.java.simpleName, "Careful! ${e}")
+                        null
+                    }
+                }
                 DESCRIPTION -> {
                     parsingDescription = false
                     elementValue = EMPTY_STRING


### PR DESCRIPTION
As for issue #8 and in terms for making it more simple to devs to filter Items by date, I make the necessary modifications to now have a Date inside the RssItem.

Added also a Log message in order to inform the existence of an unparseable date.

I tried to make changes in _dev_, but I couldn't be able to resolve the conflicts in merge. 